### PR TITLE
add an additional method to genus.to.species.tree

### DIFF
--- a/R/add.species.to.genus.R
+++ b/R/add.species.to.genus.R
@@ -40,18 +40,22 @@ add.species.to.genus<-function(tree,species,genus=NULL,where=c("root","random"))
 ## function take genus backbone tree & converts genus tree to species tree by simulating pure-birth subtrees
 ## written by Liam J. Revell 2015
 
-genus.to.species.tree<-function(tree,species){
+genus.to.species.tree<-function(tree,species, method = c("random", "star")){
 	N<-Ntip(tree)
 	genera<-tree$tip.label
 	species<-gsub(" ","_",species)
+	method <- method[1]
 	for(i in 1:N){
 		jj<-grep(paste(genera[i],"_",sep=""),species)
 		nn<-which(tree$tip.label==genera[i])
 		if(length(jj)>1){
-			h<-runif(n=1)*tree$edge.length[which(tree$edge[,2]==nn)]
-			tree$edge.length[which(tree$edge[,2]==nn)]<-
-				tree$edge.length[which(tree$edge[,2]==nn)]-h
-			sub.tree<-pbtree(n=length(jj),scale=h,tip.label=species[jj])
+			if (method == "random"){
+      				h <- runif(n = 1) * tree$edge.length[which(tree$edge[,2] == nn)]
+      				tree$edge.length[which(tree$edge[, 2] == nn)] <- tree$edge.length[which(tree$edge[, 2] == nn)] - h
+      				sub.tree <- pbtree(n = length(jj), scale = h, tip.label = species[jj])
+      				} else {
+        			sub.tree <- stree(length(jj), tip.label = species[jj])
+      			}
 			tree<-bind.tree(tree,sub.tree,where=nn)
 		} else if(length(jj)==1) tree$tip.label[nn]<-species[jj]
 	}


### PR DESCRIPTION
adds the option to append the species as polytomies instead of using the birth model subtrees.