### PR TITLE
improve bind.tree doc

### DIFF
--- a/man/bind.tip.Rd
+++ b/man/bind.tip.Rd
@@ -9,8 +9,8 @@ bind.tip(tree, tip.label, edge.length=NULL, where=NULL, position=0,
 	\item{tree}{receptor tree.}
 	\item{tip.label}{a string containing the species name for the new tip.}
 	\item{edge.length}{edge length for the new tip (a scalar).}
-	\item{where}{node number to attach new tip. If \code{position>0} then then tip will be attached \emph{below} the specified node. Node numbers can also be tips, in which case the new tip will be added along the terminal edge. To find out the tip number for given species with name \emph{"species"} type: \code{which(tree$tip.label=="species")}.}
-	\item{position}{distance \emph{below} node to add tip.}
+	\item{where}{node number to attach new tip. If \code{position>0} then then tip will be attached \emph{rootward} of the specified node. Node numbers can also be tips, in which case the new tip will be added along the terminal edge. To find out the tip number for given species with name \emph{"species"} type: \code{which(tree$tip.label=="species")}.}
+	\item{position}{distance \emph{rootward} of the node to add the new tip.}
 	\item{interactive}{logical value indicating whether or not the species should be added interactively. (Defaults to \code{FALSE}.)}
 	\item{...}{arguments to be passed to \code{plotTree} (for \code{interactive=TRUE}.)}
 }
@@ -27,5 +27,25 @@ bind.tip(tree, tip.label, edge.length=NULL, where=NULL, position=0,
 	Revell, L. J. (2012) phytools: An R package for phylogenetic comparative biology (and other things). \emph{Methods Ecol. Evol.}, \bold{3}, 217-223.
 }
 \author{Liam Revell \email{liam.revell@umb.edu}}
+\examples{
+set.seed(123)
+# generate tree
+tree<-pbtree(b=0.1, n=10)
+
+# plot original tree
+plot(tree); axisPhylo()
+
+# add an extant tip ("t_extant") sister to taxon 't5' with divergence time of 4.5 Ma
+node <- which(tree$tip.label=="t5") # the edge where the new tip will be attached
+tree <- bind.tip(tree, tip.label="t_extant", where=node, position=4.5)
+# plot to see the result
+plot(tree); axisPhylo()
+
+# add an extinct tip ("t_extinct") sister to 't2' with divergence time of 7.8 Ma and duration (edge length) of 3.3 Ma
+node <- which(tree$tip.label=="t2") # the edge where the new tip will be attached
+tree <- bind.tip(tree, tip.label="t_extinct", where=node, position=7.8, edge.length=3.3)
+# plot to see the result
+plot(tree); axisPhylo()
+}
 \keyword{phylogenetics}
 \keyword{utilities}


### PR DESCRIPTION
A student and i struggled quite a bit over the this function yesterday, in part because of the wording, and in part because no example was given. This PR addresses both.

1. 'below a node' is ambiguous. is the root assumed to be at the top of the tree or the bottom? here, 'below' is replaced by 'rootward' to be unambiguous.
2. an example is given for attaching both an extant and an extinct tip to a tree.

HTH.