### PR TITLE
allow adding a tip "above" root

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1695,7 +1695,13 @@ bind.tip<-function(tree,tip.label,edge.length=NULL,where=NULL,position=0,interac
 	} else pp<-position
 	if(is.null(edge.length)&&is.ultrametric(tree)){
 		H<-nodeHeights(tree)
-		if(where==(Ntip(tree)+1)) edge.length<-max(H)
+		if(where==(Ntip(tree)+1)){
+			edge.length<-max(H)
+			# if adding tip as outgroup that diverged before ingroup MRCA, need to take into account new root height
+			if(position>0){
+				edge.length<-edge.length+position
+			}
+		}
 		else edge.length<-max(H)-H[tree$edge[,2]==where,2]+position
 	}
 	tip<-list(edge=matrix(c(2,1),1,2),
@@ -1703,6 +1709,14 @@ bind.tip<-function(tree,tip.label,edge.length=NULL,where=NULL,position=0,interac
 		edge.length=edge.length,
 		Nnode=1)
 		class(tip)<-"phylo"
+	# if attaching tip creates new root, add root edge to attach to
+	if(where==(Ntip(tree)+1)&&position>0){
+		if(is.null(tree$root.edge)){
+			tree$root.edge<-position
+			pp<-position
+			where<-"root"
+		}
+	}
 	obj<-bind.tree(tree,tip,where=where,position=pp)
 	if(where<=Ntip(tree)&&position==0){
 		nn<-obj$edge[which(obj$edge[,2]==which(obj$tip.label==tip$tip.label)),1]


### PR DESCRIPTION
Allow adding an outgroup tip which diverged before the ingroup MRCA. The `ape::bind.tree` function which `bind.tip` wraps allows this, but the tree to which the tip is added ("x") must have a `root.edge`. The code submitted here does the necessary edits so that `bind.tree` does what is requested with no more arguments required from the user.

Examples
```
# this uses the existing example for `bind.tip`
tree<-pbtree(b=0.1, n=10);
plot(tree); axisPhylo();

# add an extant tip with known divergence time (4.5 units above root)
tree.extant <- bind.tip.alt(tree, tip.label="t_extant", position=4.5);

# plot
par(mfrow=c(1,2));
plot(tree); axisPhylo();
plot(tree.extant); axisPhylo();
par(mfrow=c(1,1));

# add an extinct tip that survived until 7.8 units before present
# 1. the root age of the original tree is RA=max(nodeHeights(tree))
# 2. we are adding position to that age (time to MRCA of all)
# so edge.length will be RA+position-7.8
RA=max(nodeHeights(tree))
EL <- RA + 4.5 - 7.8;
tree.extinct <- bind.tip.alt(tree, tip.label="t_extant", position=4.5, edge.length=EL);

# plot
par(mfrow=c(1,2));
plot(tree); axisPhylo();
plot(tree.extinct); axisPhylo();
par(mfrow=c(1,1));
```